### PR TITLE
Update to 0.15.2 and expose webadmin port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM java:8-jre
 MAINTAINER Michael Ferguson <mpherg@gmail.com>
 
-ENV BLYNK_SERVER_VERSION 0.15.0
+ENV BLYNK_SERVER_VERSION 0.15.2
 RUN mkdir /data
 RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}.jar > /data/server.jar
 
 # By default, mobile application uses port 8443 and is based on SSL/TLS
 # sockets. Default hardware port is 8442 and is based on plain TCP/IP
 # sockets.
-EXPOSE 8442 8443
+# Blynk server also has administration panel where you could monitor your 
+# server. It could be accessible with URL https://your_ip:7443/admin
+EXPOSE 7443 8442 8443
 WORKDIR /data
 ENTRYPOINT ["java", "-jar", "server.jar"]


### PR DESCRIPTION
Thanks for making this! I'm a total newbie and getting this far would have taken me forever.
I propose these changes:
- Current latest version is 0.15.2, adds fixes and new widget support (according to blynkkk repo).
- Expose port 7443 which is the default port for web administration panel (plus explanation copy&pasted from blynkkk readme).