### PR TITLE
Store server.jar and data in separate folders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,13 @@ FROM java:8-jre
 MAINTAINER Michael Ferguson <mpherg@gmail.com>
 
 ENV BLYNK_SERVER_VERSION 0.15.2
+RUN mkdir /blynk
+RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}.jar > /blynk/server.jar
+
+# Create data folder. To persist data, map a volume to /data
 RUN mkdir /data
-RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}.jar > /data/server.jar
+# Place symbolic link to server config file so that this can be persisted in /data
+RUN ln -s /data/server.properties /blynk/server.properties
 
 # By default, mobile application uses port 8443 and is based on SSL/TLS
 # sockets. Default hardware port is 8442 and is based on plain TCP/IP
@@ -12,4 +17,4 @@ RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_S
 # server. It could be accessible with URL https://your_ip:7443/admin
 EXPOSE 7443 8442 8443
 WORKDIR /data
-ENTRYPOINT ["java", "-jar", "server.jar"]
+ENTRYPOINT ["java", "-jar", "/blynk/server.jar", "-dataFolder", "/data"]


### PR DESCRIPTION
Reason for this is to be able to store data and server config file in a volume, so that this data can be made persistent and not live inside the container.

The problem with the current setup is if /data is setup as a volume mapped to a host folder, that folder overwrites the container's /data, and thereby also server.jar which was stored in that folder. 
The server.properties config file needs to be in the same folder as server.jar, but a symbolic link makes that happen and the server.properties can now be stored with the data.

If one chooses not to map /data to a volume, this docker will work the same as it used to.