### PR TITLE
Bump server version to 0.41.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-jre
 MAINTAINER Michael Ferguson <mpherg@gmail.com>
 
-ENV BLYNK_SERVER_VERSION 0.41.13
+ENV BLYNK_SERVER_VERSION 0.41.17
 RUN mkdir /blynk
 RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}.jar > /blynk/server.jar
 


### PR DESCRIPTION
Bumping up the server version to [0.14.17](https://github.com/blynkkk/blynk-server/releases/tag/v0.41.17) that includes important security fixes (Log4j2 vulnerability fix).